### PR TITLE
Allow absolute paths for scp

### DIFF
--- a/bfsscp/bfsscp_test.go
+++ b/bfsscp/bfsscp_test.go
@@ -19,6 +19,7 @@ const (
 
 var _ = Describe("Bucket", func() {
 	var opts lint.Options
+	var ctx = context.Background()
 
 	BeforeEach(func() {
 		prefix := "x/" + strconv.FormatInt(time.Now().UnixNano(), 10)
@@ -31,8 +32,31 @@ var _ = Describe("Bucket", func() {
 	})
 
 	It("should register scp scheme", func() {
-		subject, err := bfs.Connect(context.Background(), "scp://root:root@127.0.0.1:7022/prefix?tmpdir=test")
+		subject, err := bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/prefix?tmpdir=test")
 		Expect(err).NotTo(HaveOccurred())
+		Expect(subject.Close()).To(Succeed())
+	})
+
+	It("should allow for absolute and relative paths", func() {
+		subject, err := bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/prefix")
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err := subject.Create(ctx, "test", nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(f.Commit()).To(Succeed())
+
+		i, err := subject.Head(ctx, "test")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(i).NotTo(BeNil())
+
+		Expect(subject.Close()).To(Succeed())
+
+		subject, err = bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/prefix?absolute=true")
+		Expect(err).NotTo(HaveOccurred())
+		i, err = subject.Head(ctx, "test")
+		Expect(err).To(Equal(bfs.ErrNotFound))
+		Expect(i).To(BeNil())
+
 		Expect(subject.Close()).To(Succeed())
 	})
 


### PR DESCRIPTION
- Added `absolute` query param
- Only remove leading slash from Prefix when Absolute is not preferred
- Added test to ensure relative path is separated from absolute path